### PR TITLE
Add concurrency support for evm extractor

### DIFF
--- a/extract/evm_test.go
+++ b/extract/evm_test.go
@@ -368,6 +368,7 @@ func TestEthExtractorCatchUpUntilFinalized(t *testing.T) {
 			assert.NotNil(t, data)
 			assert.Equal(t, uint64(i), data.Block.Number.Uint64())
 		case <-time.After(100 * time.Millisecond):
+			close(resultChan)
 			t.Fatal("Timed out waiting for block data")
 		}
 	}

--- a/extract/extractor.go
+++ b/extract/extractor.go
@@ -41,6 +41,10 @@ type Config[T any] struct {
 
 	// PollInterval specifies how often to poll for new blocks during normal, steady-state operation.
 	PollInterval time.Duration `default:"1s"`
+
+	// Number of concurrent goroutines used for catching up to the latest finalized block.
+	// By default, runtime.GOMAXPROCS(0) is used.
+	Concurrency int
 }
 
 // EthConfig is a Config specialization for Ethereum-compatible blockchains.

--- a/extract/extractor.go
+++ b/extract/extractor.go
@@ -3,6 +3,7 @@ package extract
 import (
 	"time"
 
+	"github.com/Conflux-Chain/go-conflux-util/parallel"
 	"github.com/openweb3/go-rpc-provider"
 	"github.com/pkg/errors"
 )
@@ -20,6 +21,9 @@ func NewInconsistentChainDataError(detail string) error {
 }
 
 type Config[T any] struct {
+	// Concurrency options used for catching up to the latest finalized block.
+	parallel.SerialOption
+
 	// TargetBlockNumber is the block number the extractor is catching up to during synchronization.
 	TargetBlockNumber T
 
@@ -41,10 +45,6 @@ type Config[T any] struct {
 
 	// PollInterval specifies how often to poll for new blocks during normal, steady-state operation.
 	PollInterval time.Duration `default:"1s"`
-
-	// Number of concurrent goroutines used for catching up to the latest finalized block.
-	// By default, runtime.GOMAXPROCS(0) is used.
-	Concurrency int
 }
 
 // EthConfig is a Config specialization for Ethereum-compatible blockchains.

--- a/extract/parallel.go
+++ b/extract/parallel.go
@@ -1,0 +1,58 @@
+package extract
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/Conflux-Chain/confura-data-cache/types"
+	"github.com/Conflux-Chain/go-conflux-util/parallel"
+	ethTypes "github.com/openweb3/web3go/types"
+)
+
+var (
+	_ parallel.Interface[*types.EthBlockData] = (*EthParallelWorker)(nil)
+)
+
+type ParallelWorker[T Sizable] struct {
+	start        uint64
+	dataChan     *MemoryBoundedChannel[T]
+	numCollected atomic.Uint64
+}
+
+func (w *ParallelWorker[T]) NumCollected() uint64 {
+	return w.numCollected.Load()
+}
+
+// ParallelCollect implements parallel.Interface.
+func (w *ParallelWorker[T]) ParallelCollect(ctx context.Context, result *parallel.Result[T]) error {
+	if result.Err == nil {
+		w.dataChan.Send(result.Value)
+		w.numCollected.Add(1)
+	}
+	return result.Err
+}
+
+type EthParallelWorker struct {
+	ParallelWorker[*types.EthBlockData]
+	client EthRpcClient
+}
+
+func NewEthParallelWorker(start uint64, dataChan *EthMemoryBoundedChannel, client EthRpcClient) *EthParallelWorker {
+	return &EthParallelWorker{
+		ParallelWorker: ParallelWorker[*types.EthBlockData]{
+			start:    start,
+			dataChan: dataChan,
+		},
+		client: client,
+	}
+}
+
+// ParallelDo implements parallel.Interface.
+func (w *EthParallelWorker) ParallelDo(ctx context.Context, routine int, task int) (v *types.EthBlockData, err error) {
+	bn := w.start + uint64(task)
+	data, err := w.client.BlockBundleByNumber(ctx, ethTypes.BlockNumber(bn))
+	if err != nil {
+		return nil, err
+	}
+	return &data, nil
+}

--- a/extract/parallel_test.go
+++ b/extract/parallel_test.go
@@ -41,7 +41,7 @@ func TestEthParallelWorkerParallelDo(t *testing.T) {
 		DisableTimestamp: true,
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
 	result, err = worker.ParallelDo(ctx, 0, 1)

--- a/extract/parallel_test.go
+++ b/extract/parallel_test.go
@@ -1,0 +1,58 @@
+package extract
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/Conflux-Chain/confura-data-cache/types"
+	"github.com/Conflux-Chain/go-conflux-util/parallel"
+	ethTypes "github.com/openweb3/web3go/types"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestEthParallelWorkerParallelDo(t *testing.T) {
+	start := uint64(100)
+	mockData := types.EthBlockData{
+		Block: makeMockBlock(100, "0x100", "0x99"),
+	}
+
+	mockClient := new(MockEthRpcClient)
+	mockClient.On("BlockBundleByNumber", mock.Anything, ethTypes.BlockNumber(100)).Return(mockData, nil)
+	mockClient.On("BlockBundleByNumber", mock.Anything, ethTypes.BlockNumber(101)).
+		Return(types.EthBlockData{}, errors.New("rpc error"))
+
+	dataChan := NewEthMemoryBoundedChannel(math.MaxUint64)
+	worker := NewEthParallelWorker(start, dataChan, mockClient)
+	result, err := worker.ParallelDo(context.Background(), 0, 0)
+
+	assert.NoError(t, err)
+	assert.Equal(t, &mockData, result)
+
+	result, err = worker.ParallelDo(context.Background(), 0, 1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestParallelWorkerParallelCollect(t *testing.T) {
+	mockClient := new(MockEthRpcClient)
+	mockData := &types.EthBlockData{
+		Block: makeMockBlock(100, "0x100", "0x99"),
+	}
+
+	dataChan := NewEthMemoryBoundedChannel(math.MaxUint64)
+	worker := NewEthParallelWorker(100, dataChan, mockClient)
+	err := worker.ParallelCollect(context.Background(), &parallel.Result[*types.EthBlockData]{Value: mockData})
+
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), worker.NumCollected())
+	assert.Equal(t, mockData, dataChan.Receive())
+
+	err = worker.ParallelCollect(context.Background(), &parallel.Result[*types.EthBlockData]{Err: errors.New("rpc error")})
+	assert.Error(t, err)
+	assert.Equal(t, uint64(1), worker.NumCollected())
+}


### PR DESCRIPTION
Concurrent requests are used during catch up to the latest finalized block.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura-data-cache/27)
<!-- Reviewable:end -->
