### PR TITLE
Normalize start block number for EVM extractor

### DIFF
--- a/extract/evm.go
+++ b/extract/evm.go
@@ -125,7 +125,6 @@ func (e *EthExtractor) AppendBlockHash(blockNumber uint64, blockHash common.Hash
 // blocking the extractor.
 func (e *EthExtractor) Start(ctx context.Context, dataChan *EthMemoryBoundedChannel) {
 	defer e.rpcClient.Close()
-	defer dataChan.Close()
 
 	// Catch up to the latest finalized block.
 	e.catchUpUntilFinalized(ctx, dataChan)

--- a/extract/evm.go
+++ b/extract/evm.go
@@ -74,7 +74,7 @@ type EthExtractor struct {
 	rpcClient EthRpcClient    // Connected RPC client for fetching blockchain data
 }
 
-func NewEvmExtractor(conf EthConfig, provider ...FinalizedHeightProvider) (*EthExtractor, error) {
+func NewEthExtractor(conf EthConfig, provider ...FinalizedHeightProvider) (*EthExtractor, error) {
 	if len(conf.RpcEndpoint) == 0 {
 		return nil, errors.New("no rpc endpoint provided")
 	}
@@ -85,6 +85,18 @@ func NewEvmExtractor(conf EthConfig, provider ...FinalizedHeightProvider) (*EthE
 	}
 
 	rpcClient := &Web3ClientAdapter{client}
+	return newEthExtractorWithClient(rpcClient, conf, provider...)
+}
+
+func newEthExtractorWithClient(rpcClient EthRpcClient, conf EthConfig, provider ...FinalizedHeightProvider) (*EthExtractor, error) {
+	// Normalize start block number if necessary
+	if conf.StartBlockNumber <= 0 {
+		block, err := rpcClient.BlockHeaderByNumber(context.Background(), conf.StartBlockNumber)
+		if err != nil {
+			return nil, errors.WithMessage(err, "failed to normalize start block")
+		}
+		conf.StartBlockNumber = ethTypes.BlockNumber(block.Number.Int64())
+	}
 
 	var finalizeProvider FinalizedHeightProvider
 	if len(provider) > 0 {
@@ -113,6 +125,7 @@ func (e *EthExtractor) AppendBlockHash(blockNumber uint64, blockHash common.Hash
 // blocking the extractor.
 func (e *EthExtractor) Start(ctx context.Context, dataChan *EthMemoryBoundedChannel) {
 	defer e.rpcClient.Close()
+	defer dataChan.Close()
 
 	// Catch up to the latest finalized block.
 	e.catchUpUntilFinalized(ctx, dataChan)
@@ -163,16 +176,16 @@ func (e *EthExtractor) catchUpOnce(ctx context.Context, dataChan *EthMemoryBound
 		return errors.WithMessage(err, "failed to get finalized block"), false
 	}
 
-	finalizedBlockNumber := latestFinalizedBlock.Number.Uint64()
+	finalizedBlockNumber := ethTypes.BlockNumber(latestFinalizedBlock.Number.Int64())
 	if e.StartBlockNumber > finalizedBlockNumber {
 		return nil, true
 	}
 
-	worker := NewEthParallelWorker(e.StartBlockNumber, dataChan, e.rpcClient)
+	worker := NewEthParallelWorker(uint64(e.StartBlockNumber), dataChan, e.rpcClient)
 	numTasks := finalizedBlockNumber - e.StartBlockNumber + 1
 
 	err = parallel.Serial(ctx, worker, int(numTasks), e.SerialOption)
-	e.StartBlockNumber += worker.NumCollected()
+	e.StartBlockNumber += ethTypes.BlockNumber(worker.NumCollected())
 	if err != nil {
 		return err, false
 	}
@@ -194,7 +207,7 @@ func (e *EthExtractor) extractOnce(ctx context.Context) (*EthRevertableBlockData
 	}
 
 	// Check if we are already caught up.
-	if e.StartBlockNumber > targetBlock.Number.Uint64() {
+	if e.StartBlockNumber > ethTypes.BlockNumber(targetBlock.Number.Int64()) {
 		return nil, true, nil
 	}
 
@@ -212,7 +225,7 @@ func (e *EthExtractor) extractOnce(ctx context.Context) (*EthRevertableBlockData
 	// Check for reorgs by comparing the block parent hash with the hashes in the hash window.
 	if bn, bh, ok := e.hashCache.Latest(); ok {
 		if bh != blockData.Block.ParentHash { // reorg detected
-			e.StartBlockNumber = bn
+			e.StartBlockNumber = ethTypes.BlockNumber(bn)
 			e.hashCache.Pop()
 
 			detail := fmt.Sprintf(

--- a/extract/evm_test.go
+++ b/extract/evm_test.go
@@ -156,7 +156,7 @@ func TestNewEvmExtractor(t *testing.T) {
 		assert.Equal(t, common.HexToHash("0x1"), bh)
 	})
 
-	t.Run("NormalizedStartBlockNumber", func(t *testing.T) {
+	t.Run("NormalizedStartBlockNumberOK", func(t *testing.T) {
 		cfg := EthConfig{
 			StartBlockNumber:  ethTypes.FinalizedBlockNumber,
 			TargetBlockNumber: ethTypes.LatestBlockNumber,
@@ -168,6 +168,20 @@ func TestNewEvmExtractor(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEqual(t, ethTypes.FinalizedBlockNumber, ex.StartBlockNumber)
 		assert.Equal(t, ethTypes.BlockNumber(100), ex.StartBlockNumber)
+	})
+
+	t.Run("NormalizedStartBlockNumberError", func(t *testing.T) {
+		cfg := EthConfig{
+			StartBlockNumber:  ethTypes.FinalizedBlockNumber,
+			TargetBlockNumber: ethTypes.LatestBlockNumber,
+		}
+		c := new(MockEthRpcClient)
+		c.On("BlockHeaderByNumber", mock.Anything, cfg.StartBlockNumber).Return((*ethTypes.Block)(nil), errors.New("rpc error"))
+
+		ex, err := newEthExtractorWithClient(c, cfg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to normalize start block")
+		assert.Nil(t, ex)
 	})
 }
 

--- a/extract/evm_test.go
+++ b/extract/evm_test.go
@@ -63,7 +63,7 @@ func TestEvmExtractIntegration(t *testing.T) {
 	conf := EthConfig{RpcEndpoint: endpoint}
 	defaults.SetDefaults(&conf)
 
-	extractor, err := NewEvmExtractor(conf)
+	extractor, err := NewEthExtractor(conf)
 	assert.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -90,14 +90,27 @@ func TestNewEvmExtractor(t *testing.T) {
 		expectError bool
 		errorText   string
 	}{
-		{"NoRpcEndpoint", EthConfig{}, true, "no rpc endpoint provided"},
-		{"InvalidRpcEndpoint", EthConfig{RpcEndpoint: "invalid"}, true, "failed to create rpc client"},
-		{"ValidConfig", EthConfig{RpcEndpoint: "http://localhost:8545"}, false, ""},
+		{
+			"NoRpcEndpoint", EthConfig{
+				StartBlockNumber: ethTypes.BlockNumber(100),
+			}, true, "no rpc endpoint provided",
+		},
+		{
+			"InvalidRpcEndpoint", EthConfig{
+				StartBlockNumber: ethTypes.BlockNumber(100),
+				RpcEndpoint:      "invalid",
+			}, true, "failed to create rpc client"},
+		{
+			"ValidConfig", EthConfig{
+				StartBlockNumber: ethTypes.BlockNumber(100),
+				RpcEndpoint:      "http://localhost:8545",
+			}, false, "",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ext, err := NewEvmExtractor(tc.config)
+			ext, err := NewEthExtractor(tc.config)
 			if tc.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errorText)
@@ -109,10 +122,14 @@ func TestNewEvmExtractor(t *testing.T) {
 	}
 
 	t.Run("CustomFinalizedProviderError", func(t *testing.T) {
-		cfg := EthConfig{TargetBlockNumber: ethTypes.FinalizedBlockNumber, RpcEndpoint: "http://localhost:8545"}
+		cfg := EthConfig{
+			StartBlockNumber:  ethTypes.BlockNumber(100),
+			TargetBlockNumber: ethTypes.FinalizedBlockNumber,
+			RpcEndpoint:       "http://localhost:8545",
+		}
 		c := new(MockEthRpcClient)
 		c.On("BlockHeaderByNumber", mock.Anything, cfg.TargetBlockNumber).Return((*ethTypes.Block)(nil), errors.New("rpc error"))
-		ex, err := NewEvmExtractor(cfg, newEthFinalizedHeightProvider(c))
+		ex, err := NewEthExtractor(cfg, newEthFinalizedHeightProvider(c))
 		assert.NoError(t, err)
 
 		err = ex.hashCache.Append(1, common.HexToHash("0x1"))
@@ -120,10 +137,14 @@ func TestNewEvmExtractor(t *testing.T) {
 	})
 
 	t.Run("CustomFinalizedProviderOk", func(t *testing.T) {
-		cfg := EthConfig{TargetBlockNumber: ethTypes.FinalizedBlockNumber, RpcEndpoint: "http://localhost:8545"}
+		cfg := EthConfig{
+			TargetBlockNumber: ethTypes.FinalizedBlockNumber,
+			RpcEndpoint:       "http://localhost:8545",
+			StartBlockNumber:  ethTypes.BlockNumber(100),
+		}
 		c := new(MockEthRpcClient)
 		c.On("BlockHeaderByNumber", mock.Anything, cfg.TargetBlockNumber).Return(makeMockBlock(100, "0x100", "0x99"), nil)
-		ex, err := NewEvmExtractor(cfg, newEthFinalizedHeightProvider(c))
+		ex, err := NewEthExtractor(cfg, newEthFinalizedHeightProvider(c))
 		assert.NoError(t, err)
 
 		err = ex.hashCache.Append(1, common.HexToHash("0x1"))
@@ -133,6 +154,20 @@ func TestNewEvmExtractor(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, uint64(1), bn)
 		assert.Equal(t, common.HexToHash("0x1"), bh)
+	})
+
+	t.Run("NormalizedStartBlockNumber", func(t *testing.T) {
+		cfg := EthConfig{
+			StartBlockNumber:  ethTypes.FinalizedBlockNumber,
+			TargetBlockNumber: ethTypes.LatestBlockNumber,
+		}
+		c := new(MockEthRpcClient)
+		c.On("BlockHeaderByNumber", mock.Anything, cfg.StartBlockNumber).Return(makeMockBlock(100, "0x100", "0x99"), nil)
+
+		ex, err := newEthExtractorWithClient(c, cfg)
+		assert.NoError(t, err)
+		assert.NotEqual(t, ethTypes.FinalizedBlockNumber, ex.StartBlockNumber)
+		assert.Equal(t, ethTypes.BlockNumber(100), ex.StartBlockNumber)
 	})
 }
 
@@ -405,7 +440,7 @@ func TestEthExtractorCatchUpUntilFinalized(t *testing.T) {
 			t.Fatal("Timed out waiting for block data")
 		}
 	}
-	assert.Equal(t, ex.StartBlockNumber, uint64(101))
+	assert.Equal(t, ex.StartBlockNumber, ethTypes.BlockNumber(101))
 }
 
 func TestCatchUpOnce(t *testing.T) {

--- a/extract/extractor.go
+++ b/extract/extractor.go
@@ -32,16 +32,12 @@ type Config[T any] struct {
 
 	// Optional starting block number for sync.
 	// If not set (i.e., 0), sync will start from the earliest block.
-	StartBlockNumber uint64
-
-	// Size of the internal buffer (in number of blocks) to store fetched block data before processing.
-	// Acts as a channel queue size between data producer and consumer.
-	BufferSize int `default:"200"`
+	StartBlockNumber T
 
 	// Maximum memory (in bytes) the extractor is allowed to use.
 	// If memory usage exceeds this limit, syncing will be paused.
 	// Default is 256MB (268,435,456 bytes).
-	MaxMemoryUsageBytes uint64 `default:"268435456"`
+	MaxMemoryUsageBytes int `default:"268435456"`
 
 	// PollInterval specifies how often to poll for new blocks during normal, steady-state operation.
 	PollInterval time.Duration `default:"1s"`


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura-data-cache/39)
<!-- Reviewable:end -->
