### PR TITLE
Modify `MemoryBoundedChannel` behavior after closed

### DIFF
--- a/extract/bound.go
+++ b/extract/bound.go
@@ -44,7 +44,7 @@ func NewMemoryBoundedChannel[T any](capacity int) *MemoryBoundedChannel[T] {
 	return m
 }
 
-// Send blocks until enough memory is available to buffer the item, or returns an error if the channel is closed.
+// Send blocks until enough memory is available to buffer the item, or returns ErrChannelClosed if the channel is closed.
 func (m *MemoryBoundedChannel[T]) Send(item types.Sized[T]) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -64,7 +64,7 @@ func (m *MemoryBoundedChannel[T]) Send(item types.Sized[T]) error {
 }
 
 // TrySend attempts to send without blocking.
-// It returns false if over memory limit, or an error if the channel is closed.
+// It returns false if over memory limit, or ErrChannelClosed if the channel is closed.
 func (m *MemoryBoundedChannel[T]) TrySend(item types.Sized[T]) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -80,7 +80,7 @@ func (m *MemoryBoundedChannel[T]) TrySend(item types.Sized[T]) (bool, error) {
 	return true, nil
 }
 
-// Receive blocks until an item is available and returns it, or returns an error if the channel is closed.
+// Receive blocks until an item is available and returns it, or returns ErrChannelClosed if the channel is closed.
 func (m *MemoryBoundedChannel[T]) Receive() (v T, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -95,7 +95,7 @@ func (m *MemoryBoundedChannel[T]) Receive() (v T, err error) {
 	return v, ErrChannelClosed
 }
 
-// TryReceive returns an item if available, or false if the channel is empty or an error if the channel is closed.
+// TryReceive returns an item if available, or false if the channel is empty or ErrChannelClosed if the channel is closed.
 func (m *MemoryBoundedChannel[T]) TryReceive() (v T, ok bool, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/extract/bound.go
+++ b/extract/bound.go
@@ -5,6 +5,11 @@ import (
 	"sync"
 
 	"github.com/Conflux-Chain/confura-data-cache/types"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrChannelClosed = errors.New("channel closed")
 )
 
 // RevertableBlockData wraps a block data with optional reorg information.
@@ -39,41 +44,44 @@ func NewMemoryBoundedChannel[T any](capacity int) *MemoryBoundedChannel[T] {
 	return m
 }
 
-// Send blocks until enough memory is available to buffer the item.
-func (m *MemoryBoundedChannel[T]) Send(item types.Sized[T]) {
+// Send blocks until enough memory is available to buffer the item, or returns an error if the channel is closed.
+func (m *MemoryBoundedChannel[T]) Send(item types.Sized[T]) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	for {
 		if m.closed {
-			panic("send on closed channel")
+			return ErrChannelClosed
 		}
 		if !(m.size+item.Size > m.capacity && m.buffer.Len() > 0) {
 			break
 		}
 		m.notFullCond.Wait()
 	}
+
 	m.enqueue(item)
+	return nil
 }
 
-// TrySend attempts to send without blocking. Returns false if over memory limit.
-func (m *MemoryBoundedChannel[T]) TrySend(item types.Sized[T]) bool {
+// TrySend attempts to send without blocking.
+// It returns false if over memory limit, or an error if the channel is closed.
+func (m *MemoryBoundedChannel[T]) TrySend(item types.Sized[T]) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if m.closed {
-		panic("send on closed channel")
+		return false, ErrChannelClosed
 	}
 
 	if m.size+item.Size > m.capacity && m.buffer.Len() > 0 {
-		return false
+		return false, nil
 	}
 	m.enqueue(item)
-	return true
+	return true, nil
 }
 
-// Receive blocks until an item is available and returns it.
-func (m *MemoryBoundedChannel[T]) Receive() (v T) {
+// Receive blocks until an item is available and returns it, or returns an error if the channel is closed.
+func (m *MemoryBoundedChannel[T]) Receive() (v T, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -82,18 +90,21 @@ func (m *MemoryBoundedChannel[T]) Receive() (v T) {
 	}
 
 	if m.buffer.Len() > 0 {
-		return m.dequeue()
+		return m.dequeue(), nil
 	}
-	return
+	return v, ErrChannelClosed
 }
 
-// TryReceive returns an item if available, otherwise false.
-func (m *MemoryBoundedChannel[T]) TryReceive() (v T, ok bool) {
+// TryReceive returns an item if available, or false if the channel is empty or an error if the channel is closed.
+func (m *MemoryBoundedChannel[T]) TryReceive() (v T, ok bool, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if m.buffer.Len() > 0 {
-		v, ok = m.dequeue(), true
+		return m.dequeue(), true, nil
+	}
+	if m.closed {
+		err = ErrChannelClosed
 	}
 	return
 }

--- a/extract/evm_test.go
+++ b/extract/evm_test.go
@@ -72,7 +72,8 @@ func TestEvmExtractIntegration(t *testing.T) {
 	dataChan := NewEthMemoryBoundedChannel(math.MaxInt)
 	go extractor.Start(ctx, dataChan)
 
-	data := dataChan.Receive()
+	data, err := dataChan.Receive()
+	assert.NoError(t, err)
 	assert.NotNil(t, data)
 	assert.Nil(t, data.ReorgHeight)
 	assert.NotNil(t, data.BlockData)
@@ -406,7 +407,9 @@ func TestEthExtractorStart(t *testing.T) {
 
 		resultChan := make(chan *EthRevertableBlockData)
 		go func() {
-			resultChan <- dataChan.Receive()
+			data, err := dataChan.Receive()
+			assert.NoError(t, err)
+			resultChan <- data
 		}()
 
 		select {
@@ -440,7 +443,9 @@ func TestEthExtractorCatchUpUntilFinalized(t *testing.T) {
 	for i := 98; i <= 100; i++ {
 		resultChan := make(chan *EthRevertableBlockData)
 		go func() {
-			resultChan <- dataChan.Receive()
+			data, err := dataChan.Receive()
+			assert.NoError(t, err)
+			resultChan <- data
 		}()
 
 		select {

--- a/extract/parallel_test.go
+++ b/extract/parallel_test.go
@@ -70,7 +70,8 @@ func TestParallelWorkerParallelCollect(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1), worker.NumCollected())
 
-	result := dataChan.Receive()
+	result, err := dataChan.Receive()
+	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Nil(t, result.ReorgHeight)
 	assert.NotNil(t, result.BlockData)


### PR DESCRIPTION
1. Sending over closed channel returns error rather than panic
2. Receiving from empty closed channel returns error instead of empty

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura-data-cache/42)
<!-- Reviewable:end -->
