### PR TITLE
Add coverage range wrapping to nearhead cache results

### DIFF
--- a/nearhead/cache.go
+++ b/nearhead/cache.go
@@ -16,6 +16,13 @@ type Config struct {
 	MaxLogs   int    `default:"10000"`
 }
 
+// EthCacheResultWithCoverage wraps a cache lookup result together with
+// the current nearhead cache coverage.
+type EthCacheResultWithCoverage[T any] struct {
+	Result   T
+	Coverage [2]uint64 // [from (inclusive), to (exclusive)]
+}
+
 // EthCache is used to cache near head data
 type EthCache struct {
 	config  Config
@@ -127,22 +134,25 @@ func (c *EthCache) del(bn uint64) {
 }
 
 // GetBlock returns block with given number or hash.
-func (c *EthCache) GetBlock(bhon types.BlockHashOrNumber, isFull bool) *ethTypes.Block {
+func (c *EthCache) GetBlock(bhon types.BlockHashOrNumber, isFull bool) (result EthCacheResultWithCoverage[*ethTypes.Block]) {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
 
 	blockNumber := c.getBlockNumber(bhon)
 	if blockNumber == nil {
-		return nil
+		return result
 	}
 
 	data, exists := c.blockNumber2BlockDatas[*blockNumber]
 	if !exists {
-		return nil
+		return result
 	}
 
 	if isFull {
-		return data.Block
+		return EthCacheResultWithCoverage[*ethTypes.Block]{
+			Result:   data.Block,
+			Coverage: [2]uint64{c.start, c.end},
+		}
 	}
 
 	txs := data.Block.Transactions.Transactions()
@@ -154,7 +164,11 @@ func (c *EthCache) GetBlock(bhon types.BlockHashOrNumber, isFull bool) *ethTypes
 
 	block := *data.Block
 	block.Transactions = *txOrHashList
-	return &block
+
+	return EthCacheResultWithCoverage[*ethTypes.Block]{
+		Result:   &block,
+		Coverage: [2]uint64{c.start, c.end},
+	}
 }
 
 // GetTransactionByHash returns transaction with given transaction hash.
@@ -177,21 +191,24 @@ func (c *EthCache) GetTransactionByHash(txHash common.Hash) *ethTypes.Transactio
 }
 
 // GetBlockReceipts returns the receipts of a given block number or hash.
-func (c *EthCache) GetBlockReceipts(bhon types.BlockHashOrNumber) []*ethTypes.Receipt {
+func (c *EthCache) GetBlockReceipts(bhon types.BlockHashOrNumber) (result EthCacheResultWithCoverage[[]*ethTypes.Receipt]) {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
 
 	blockNumber := c.getBlockNumber(bhon)
 	if blockNumber == nil {
-		return nil
+		return result
 	}
 
 	data, exists := c.blockNumber2BlockDatas[*blockNumber]
 	if !exists {
-		return nil
+		return result
 	}
 
-	return data.Receipts
+	return EthCacheResultWithCoverage[[]*ethTypes.Receipt]{
+		Result:   data.Receipts,
+		Coverage: [2]uint64{c.start, c.end},
+	}
 }
 
 // GetTransactionReceipt returns transaction receipt by transaction hash.
@@ -213,21 +230,24 @@ func (c *EthCache) GetTransactionReceipt(txHash common.Hash) *ethTypes.Receipt {
 }
 
 // GetBlockTraces returns all traces produced at given block by number or hash
-func (c *EthCache) GetBlockTraces(bhon types.BlockHashOrNumber) []ethTypes.LocalizedTrace {
+func (c *EthCache) GetBlockTraces(bhon types.BlockHashOrNumber) (result EthCacheResultWithCoverage[[]ethTypes.LocalizedTrace]) {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
 
 	blockNumber := c.getBlockNumber(bhon)
 	if blockNumber == nil {
-		return nil
+		return result
 	}
 
 	data, exists := c.blockNumber2BlockDatas[*blockNumber]
 	if !exists {
-		return nil
+		return result
 	}
 
-	return data.Traces
+	return EthCacheResultWithCoverage[[]ethTypes.LocalizedTrace]{
+		Result:   data.Traces,
+		Coverage: [2]uint64{c.start, c.end},
+	}
 }
 
 // GetTransactionTraces returns all traces of given transaction.

--- a/nearhead/cache.go
+++ b/nearhead/cache.go
@@ -134,9 +134,13 @@ func (c *EthCache) del(bn uint64) {
 }
 
 // GetBlock returns block with given number or hash.
-func (c *EthCache) GetBlock(bhon types.BlockHashOrNumber, isFull bool) (result EthCacheResultWithCoverage[*ethTypes.Block]) {
+func (c *EthCache) GetBlock(bhon types.BlockHashOrNumber, isFull bool) EthCacheResultWithCoverage[*ethTypes.Block] {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
+
+	result := EthCacheResultWithCoverage[*ethTypes.Block]{
+		Coverage: [2]uint64{c.start, c.end},
+	}
 
 	blockNumber := c.getBlockNumber(bhon)
 	if blockNumber == nil {
@@ -149,10 +153,8 @@ func (c *EthCache) GetBlock(bhon types.BlockHashOrNumber, isFull bool) (result E
 	}
 
 	if isFull {
-		return EthCacheResultWithCoverage[*ethTypes.Block]{
-			Result:   data.Block,
-			Coverage: [2]uint64{c.start, c.end},
-		}
+		result.Result = data.Block
+		return result
 	}
 
 	txs := data.Block.Transactions.Transactions()
@@ -165,10 +167,8 @@ func (c *EthCache) GetBlock(bhon types.BlockHashOrNumber, isFull bool) (result E
 	block := *data.Block
 	block.Transactions = *txOrHashList
 
-	return EthCacheResultWithCoverage[*ethTypes.Block]{
-		Result:   &block,
-		Coverage: [2]uint64{c.start, c.end},
-	}
+	result.Result = &block
+	return result
 }
 
 // GetTransactionByHash returns transaction with given transaction hash.
@@ -191,9 +191,13 @@ func (c *EthCache) GetTransactionByHash(txHash common.Hash) *ethTypes.Transactio
 }
 
 // GetBlockReceipts returns the receipts of a given block number or hash.
-func (c *EthCache) GetBlockReceipts(bhon types.BlockHashOrNumber) (result EthCacheResultWithCoverage[[]*ethTypes.Receipt]) {
+func (c *EthCache) GetBlockReceipts(bhon types.BlockHashOrNumber) EthCacheResultWithCoverage[[]*ethTypes.Receipt] {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
+
+	result := EthCacheResultWithCoverage[[]*ethTypes.Receipt]{
+		Coverage: [2]uint64{c.start, c.end},
+	}
 
 	blockNumber := c.getBlockNumber(bhon)
 	if blockNumber == nil {
@@ -205,10 +209,8 @@ func (c *EthCache) GetBlockReceipts(bhon types.BlockHashOrNumber) (result EthCac
 		return result
 	}
 
-	return EthCacheResultWithCoverage[[]*ethTypes.Receipt]{
-		Result:   data.Receipts,
-		Coverage: [2]uint64{c.start, c.end},
-	}
+	result.Result = data.Receipts
+	return result
 }
 
 // GetTransactionReceipt returns transaction receipt by transaction hash.
@@ -230,9 +232,13 @@ func (c *EthCache) GetTransactionReceipt(txHash common.Hash) *ethTypes.Receipt {
 }
 
 // GetBlockTraces returns all traces produced at given block by number or hash
-func (c *EthCache) GetBlockTraces(bhon types.BlockHashOrNumber) (result EthCacheResultWithCoverage[[]ethTypes.LocalizedTrace]) {
+func (c *EthCache) GetBlockTraces(bhon types.BlockHashOrNumber) EthCacheResultWithCoverage[[]ethTypes.LocalizedTrace] {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
+
+	result := EthCacheResultWithCoverage[[]ethTypes.LocalizedTrace]{
+		Coverage: [2]uint64{c.start, c.end},
+	}
 
 	blockNumber := c.getBlockNumber(bhon)
 	if blockNumber == nil {
@@ -244,10 +250,8 @@ func (c *EthCache) GetBlockTraces(bhon types.BlockHashOrNumber) (result EthCache
 		return result
 	}
 
-	return EthCacheResultWithCoverage[[]ethTypes.LocalizedTrace]{
-		Result:   data.Traces,
-		Coverage: [2]uint64{c.start, c.end},
-	}
+	result.Result = data.Traces
+	return result
 }
 
 // GetTransactionTraces returns all traces of given transaction.

--- a/nearhead/cache_test.go
+++ b/nearhead/cache_test.go
@@ -218,20 +218,20 @@ func TestEthCache_GetBlockByHash(t *testing.T) {
 
 	block := cache.GetBlock(types.BlockHashOrNumberWithHex("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), false)
 	assert.NotNil(t, block)
-	assert.Equal(t, uint64(120177555), block.Number.Uint64())
-	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), block.Hash)
-	assert.Len(t, block.Transactions.Hashes(), 1)
+	assert.Equal(t, uint64(120177555), block.Result.Number.Uint64())
+	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), block.Result.Hash)
+	assert.Len(t, block.Result.Transactions.Hashes(), 1)
 
 	// get block by hash with tx hashes
 	block = cache.GetBlock(types.BlockHashOrNumberWithHex("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), true)
 	assert.NotNil(t, block)
-	assert.Equal(t, uint64(120177555), block.Number.Uint64())
-	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), block.Hash)
-	assert.Len(t, block.Transactions.Transactions(), 1)
+	assert.Equal(t, uint64(120177555), block.Result.Number.Uint64())
+	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), block.Result.Hash)
+	assert.Len(t, block.Result.Transactions.Transactions(), 1)
 
 	// get block by hash that not exists
 	block = cache.GetBlock(types.BlockHashOrNumberWithHash(hashNotCached), false)
-	assert.Nil(t, block)
+	assert.Nil(t, block.Result)
 }
 
 func TestEthCache_GetBlockByNumber(t *testing.T) {
@@ -242,20 +242,20 @@ func TestEthCache_GetBlockByNumber(t *testing.T) {
 	// get block by number with tx details
 	block := cache.GetBlock(types.BlockHashOrNumberWithNumber(120177555), false)
 	assert.NotNil(t, block)
-	assert.Equal(t, uint64(120177555), block.Number.Uint64())
-	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), block.Hash)
-	assert.Len(t, block.Transactions.Hashes(), 1)
+	assert.Equal(t, uint64(120177555), block.Result.Number.Uint64())
+	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), block.Result.Hash)
+	assert.Len(t, block.Result.Transactions.Hashes(), 1)
 
 	// get block by number with tx hashes
 	block = cache.GetBlock(types.BlockHashOrNumberWithNumber(120177555), true)
 	assert.NotNil(t, block)
-	assert.Equal(t, uint64(120177555), block.Number.Uint64())
-	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), block.Hash)
-	assert.Len(t, block.Transactions.Transactions(), 1)
+	assert.Equal(t, uint64(120177555), block.Result.Number.Uint64())
+	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), block.Result.Hash)
+	assert.Len(t, block.Result.Transactions.Transactions(), 1)
 
 	// get block by number that not exists
 	block = cache.GetBlock(types.BlockHashOrNumberWithNumber(bnNotCached), false)
-	assert.Nil(t, block)
+	assert.Nil(t, block.Result)
 }
 
 func TestEthCache_GetTransactionByHash(t *testing.T) {
@@ -280,27 +280,27 @@ func TestEthCache_GetBlockReceipts(t *testing.T) {
 
 	// get block receipts by number
 	receipts := cache.GetBlockReceipts(types.BlockHashOrNumberWithNumber(120177555))
-	assert.NotNil(t, receipts)
-	assert.Len(t, receipts, 1)
-	assert.Equal(t, uint64(120177555), receipts[0].BlockNumber)
-	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), receipts[0].BlockHash)
-	assert.Equal(t, common.HexToHash("0x302df74adbc6f7481d341c2e09814b7e777624d05e3caccbc51a351f7749bb19"), receipts[0].TransactionHash)
+	assert.NotNil(t, receipts.Result)
+	assert.Len(t, receipts.Result, 1)
+	assert.Equal(t, uint64(120177555), receipts.Result[0].BlockNumber)
+	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), receipts.Result[0].BlockHash)
+	assert.Equal(t, common.HexToHash("0x302df74adbc6f7481d341c2e09814b7e777624d05e3caccbc51a351f7749bb19"), receipts.Result[0].TransactionHash)
 
 	// get block receipts by hash
 	receipts = cache.GetBlockReceipts(types.BlockHashOrNumberWithHex("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"))
-	assert.NotNil(t, receipts)
-	assert.Len(t, receipts, 1)
-	assert.Equal(t, uint64(120177555), receipts[0].BlockNumber)
-	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), receipts[0].BlockHash)
-	assert.Equal(t, common.HexToHash("0x302df74adbc6f7481d341c2e09814b7e777624d05e3caccbc51a351f7749bb19"), receipts[0].TransactionHash)
+	assert.NotNil(t, receipts.Result)
+	assert.Len(t, receipts.Result, 1)
+	assert.Equal(t, uint64(120177555), receipts.Result[0].BlockNumber)
+	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), receipts.Result[0].BlockHash)
+	assert.Equal(t, common.HexToHash("0x302df74adbc6f7481d341c2e09814b7e777624d05e3caccbc51a351f7749bb19"), receipts.Result[0].TransactionHash)
 
 	// get block receipts by number that not exists
 	receipts = cache.GetBlockReceipts(types.BlockHashOrNumberWithNumber(bnNotCached))
-	assert.Nil(t, receipts)
+	assert.Nil(t, receipts.Result)
 
 	// get block receipts by hash that not exists
 	receipts = cache.GetBlockReceipts(types.BlockHashOrNumberWithHash(hashNotCached))
-	assert.Nil(t, receipts)
+	assert.Nil(t, receipts.Result)
 }
 
 func TestEthCache_GetTransactionReceipt(t *testing.T) {
@@ -326,25 +326,25 @@ func TestEthCache_GetBlockTraces(t *testing.T) {
 
 	// get block traces by number
 	traces := cache.GetBlockTraces(types.BlockHashOrNumberWithNumber(120177555))
-	assert.NotNil(t, traces)
-	assert.Len(t, traces, 6)
-	assert.Equal(t, uint64(120177555), traces[0].BlockNumber)
-	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), traces[0].BlockHash)
+	assert.NotNil(t, traces.Result)
+	assert.Len(t, traces.Result, 6)
+	assert.Equal(t, uint64(120177555), traces.Result[0].BlockNumber)
+	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), traces.Result[0].BlockHash)
 
 	// get block traces by hash
 	traces = cache.GetBlockTraces(types.BlockHashOrNumberWithHex("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"))
-	assert.NotNil(t, traces)
-	assert.Len(t, traces, 6)
-	assert.Equal(t, uint64(120177555), traces[0].BlockNumber)
-	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), traces[0].BlockHash)
+	assert.NotNil(t, traces.Result)
+	assert.Len(t, traces.Result, 6)
+	assert.Equal(t, uint64(120177555), traces.Result[0].BlockNumber)
+	assert.Equal(t, common.HexToHash("0x5f9cecca56bd3bfda5ba448b36e7f22c9448ed52b2eff79379e38ab5b4c421e6"), traces.Result[0].BlockHash)
 
 	// get block traces by number that not exists
 	traces = cache.GetBlockTraces(types.BlockHashOrNumberWithNumber(bnNotCached))
-	assert.Nil(t, traces)
+	assert.Nil(t, traces.Result)
 
 	// get block traces by hash that not exists
 	traces = cache.GetBlockTraces(types.BlockHashOrNumberWithHash(hashNotCached))
-	assert.Nil(t, traces)
+	assert.Nil(t, traces.Result)
 }
 
 func TestEthCache_GetTransactionTraces(t *testing.T) {


### PR DESCRIPTION
Wrap `EthCache` query results with block coverage information to indicate the current cache span for `GetBlock`, `GetBlockReceipts`, and `GetBlockTraces`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura-data-cache/80)
<!-- Reviewable:end -->
